### PR TITLE
Fixing compilation error.

### DIFF
--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -146,9 +146,6 @@ func (c *CodecRequest) ReadRequest(args interface{}) error {
 
 // WriteResponse encodes the response and writes it to the ResponseWriter.
 func (c *CodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}) {
-	if c.err != nil {
-		return c.err
-	}
 	res := &serverResponse{
 		Version: Version,
 		Result:  reply,


### PR DESCRIPTION
Hi, 
    Thanks for pulling this. There is a small compilation error.
I will keep working on this to make it better.
LGTM for the api change you did regarding WriteResponse.
JSON RPC 2 send errors as 200 OK, with error set in the response object.
If anything fishy happens during write response, I set 400. Let me know if you wanna change it.

Regards,
Ranveer.
