### PR TITLE
JSON RPC 2.0 allow params to be omitted.

### DIFF
--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -136,11 +136,6 @@ func (c *CodecRequest) ReadRequest(args interface{}) error {
 					Data:    c.request.Params,
 				}
 			}
-		} else {
-			c.err = &Error{
-				Code:    E_INVALID_REQ,
-				Message: "rpc: method request ill-formed: missing params field",
-			}
 		}
 	}
 	return c.err


### PR DESCRIPTION
Implementation for service methods can use any pointer to an exported or builtin type for args then.
No need to define a type for unused args.
