### PR TITLE
When writing errors, set the response status code to an HTTP error code.

### DIFF
--- a/v2/json2/error.go
+++ b/v2/json2/error.go
@@ -31,3 +31,10 @@ type Error struct {
 func (e *Error) Error() string {
 	return e.Message
 }
+
+func (e *Error) HTTPStatus() int {
+	if e.Code == E_INTERNAL || e.Code == E_SERVER {
+		return 500
+	}
+	return 400 // all other errors are based on a Bad Request
+}

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -169,6 +169,7 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) 
 		Error:   jsonErr,
 		Id:      c.request.Id,
 	}
+	w.WriteHeader(status)
 	c.writeServerResponse(w, res)
 }
 

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -169,7 +169,7 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) 
 		Error:   jsonErr,
 		Id:      c.request.Id,
 	}
-	w.WriteHeader(status)
+	w.WriteHeader(jsonErr.HTTPStatus())
 	c.writeServerResponse(w, res)
 }
 

--- a/v2/protorpc/server.go
+++ b/v2/protorpc/server.go
@@ -131,6 +131,7 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) 
 		}{err.Error()},
 		Id: c.request.Id,
 	}
+	w.WriteHeader(status)
 	c.writeServerResponse(w, status, res)
 }
 


### PR DESCRIPTION
It would be useful to return a different status code (than 200) for errors, either a fixed one (like 500), or something the user could specify.

Most HTTP clients (especially those in the browser) have mechanisms to handle errors differently, and are based on the HTTP status code.