### PR TITLE
fixes go vet warnings for protorpc_test.go

### DIFF
--- a/protorpc/protorpc_test.go
+++ b/protorpc/protorpc_test.go
@@ -70,20 +70,18 @@ func TestService(t *testing.T) {
 		t.Error("Expected err to be nil, but got:", err)
 	}
 	if res.Result != 8 {
-		t.Errorf("Wrong response: %v.", res.Result)
+		t.Error("Expected res.Result to be 8, but got:", res.Result)
 	}
 	if res.ErrorMessage != "" {
-		t.Errorf("Expected error_message to be empty, but got:", res.ErrorMessage)
+		t.Error("Expected error_message to be empty, but got:", res.ErrorMessage)
 	}
-
 	if code, err := execute(t, s, "Service1.ResponseError", &Service1Request{4, 2}, &res); err != nil || code != 500 {
-		t.Errorf("Expected code to be 500 and error to be nil, but got", code, err)
+		t.Errorf("Expected code to be 500 and error to be nil, but got %v (%v)", code, err)
 	}
 	if res.ErrorMessage == "" {
 		t.Errorf("Expected error_message to be %q, but got %q", ErrResponseError, res.ErrorMessage)
 	}
-
 	if code, _ := execute(t, s, "Service1.Multiply", nil, &res); code != 400 {
-		t.Errorf("Expected http response code 400, but got %v", code)
+		t.Error("Expected http response code 400, but got", code)
 	}
 }

--- a/v2/protorpc/protorpc_test.go
+++ b/v2/protorpc/protorpc_test.go
@@ -67,24 +67,21 @@ func TestService(t *testing.T) {
 
 	var res Service1Response
 	if _, err := execute(t, s, "Service1.Multiply", &Service1Request{4, 2}, &res); err != nil {
-		t.Errorf("Expected err to be nil, but got: %v", err)
+		t.Error("Expected err to be nil, but got:", err)
 	}
 	if res.Result != 8 {
-		t.Errorf("Wrong response: %v.", res.Result)
+		t.Error("Expected res.Result to be 8, but got:", res.Result)
 	}
 	if res.ErrorMessage != "" {
-		t.Errorf("Expected error_message to be empty, but got:", res.ErrorMessage)
+		t.Error("Expected error_message to be empty, but got:", res.ErrorMessage)
 	}
-
-	// Should this code be 500?
 	if code, err := execute(t, s, "Service1.ResponseError", &Service1Request{4, 2}, &res); err != nil || code != 400 {
-		t.Errorf("Expected code to be 500 and error to be nil, but got %v (%v)", code, err)
+		t.Errorf("Expected code to be 400 and error to be nil, but got %v (%v)", code, err)
 	}
 	if res.ErrorMessage == "" {
 		t.Errorf("Expected error_message to be %q, but got %q", ErrResponseError, res.ErrorMessage)
 	}
-
 	if code, _ := execute(t, s, "Service1.Multiply", nil, &res); code != 400 {
-		t.Errorf("Expected http response code 400, but got %v", code)
+		t.Error("Expected http response code 400, but got", code)
 	}
 }


### PR DESCRIPTION
1) go vet complains about protorpc_test.go:

rpc/protorpc/protorpc_test.go:76: no formatting directive in Errorf call
rpc/protorpc/protorpc_test.go:80: no formatting directive in Errorf call
rpc/v2/protorpc/protorpc_test.go:76: no formatting directive in Errorf call

This fix changes every Errorf that does not use any special formatting to a Error call.

2) I removed a comment at v2/protorpc/protorpc_test.go:79 and updated test description. Error code 400 is set explicitly at:

https://github.com/gorilla/rpc/blob/master/v2/server.go#L150

which I assume was intentional change comparing to v1 version (which yield HTTP 500 for this test-case).
