### PR TITLE
Support before/after functions

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -109,7 +109,7 @@ func TestServiceBeforeAfter(t *testing.T) {
 	s.RegisterCodec(NewCodec(), "application/json")
 	service := Service1{}
 	service.beforeAfterContext = map[string]string{}
-	s.RegisterService(new(service), "")
+	s.RegisterService(service, "")
 
 	s.RegisterBeforeFunc(func(i *rpc.RequestInfo) {
 		service.beforeAfterContext["before"] = "Before is true"

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -107,7 +107,7 @@ func TestService(t *testing.T) {
 func TestServiceBeforeAfter(t *testing.T) {
 	s := rpc.NewServer()
 	s.RegisterCodec(NewCodec(), "application/json")
-	service := Service1{}
+	service := &Service1{}
 	service.beforeAfterContext = map[string]string{}
 	s.RegisterService(service, "")
 

--- a/json/server.go
+++ b/json/server.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/segmentio/gorilla-rpc"
+	"github.com/gorilla/rpc"
 )
 
 var null = json.RawMessage([]byte("null"))

--- a/json/server.go
+++ b/json/server.go
@@ -8,8 +8,9 @@ package json
 import (
 	"encoding/json"
 	"errors"
-	"github.com/gorilla/rpc"
 	"net/http"
+
+	"github.com/segmentio/gorilla-rpc"
 )
 
 var null = json.RawMessage([]byte("null"))

--- a/server.go
+++ b/server.go
@@ -49,7 +49,7 @@ func NewServer() *Server {
 type RequestInfo struct {
 	Method     string
 	Error      error
-	Request    http.Request
+	Request    *http.Request
 	StatusCode int
 }
 

--- a/server.go
+++ b/server.go
@@ -45,18 +45,20 @@ func NewServer() *Server {
 	}
 }
 
-type AfterFunc func(i *RequestInfo)
-
+// RequestInfo contains all the information we pass to before/after functions
 type RequestInfo struct {
-	Method string
-	Error  error
+	Method     string
+	Error      error
+	Request    http.Request
+	StatusCode int
 }
 
 // Server serves registered RPC services using registered codecs.
 type Server struct {
-	codecs    map[string]Codec
-	services  *serviceMap
-	afterFunc *AfterFunc
+	codecs     map[string]Codec
+	services   *serviceMap
+	beforeFunc *func(i *RequestInfo)
+	afterFunc  *func(i *RequestInfo)
 }
 
 // RegisterCodec adds a new codec to the server.
@@ -119,16 +121,22 @@ func (s *Server) HasMethod(method string) bool {
 	return false
 }
 
+// RegisterBeforeFunc registers the specified function as the function
+// that will be called before every request
+func (s *Server) RegisterBeforeFunc(f func(i *RequestInfo)) {
+	s.beforeFunc = &f
+}
+
 // RegisterAfterFunc registers the specified function as the function
-// that will be called after every request containing
-func (s *Server) RegisterAfterFunc(f AfterFunc) {
+// that will be called after every request
+func (s *Server) RegisterAfterFunc(f func(i *RequestInfo)) {
 	s.afterFunc = &f
 }
 
 // ServeHTTP
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		writeError(w, 405, "rpc: POST method required, received "+r.Method)
+		s.writeError(w, 405, "rpc: POST method required, received "+r.Method)
 		return
 	}
 	contentType := r.Header.Get("Content-Type")
@@ -138,7 +146,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	codec := s.codecs[strings.ToLower(contentType)]
 	if codec == nil {
-		writeError(w, 415, "rpc: unrecognized Content-Type: "+contentType)
+		s.writeError(w, 415, "rpc: unrecognized Content-Type: "+contentType)
 		return
 	}
 	// Create a new codec request.
@@ -146,20 +154,29 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get service method to be called.
 	method, errMethod := codecReq.Method()
 	if errMethod != nil {
-		writeError(w, 400, errMethod.Error())
+		s.writeError(w, 400, errMethod.Error())
 		return
 	}
 	serviceSpec, methodSpec, errGet := s.services.get(method)
 	if errGet != nil {
-		writeError(w, 400, errGet.Error())
+		s.writeError(w, 400, errGet.Error())
 		return
 	}
 	// Decode the args.
 	args := reflect.New(methodSpec.argsType)
 	if errRead := codecReq.ReadRequest(args.Interface()); errRead != nil {
-		writeError(w, 400, errRead.Error())
+		s.writeError(w, 400, errRead.Error())
 		return
 	}
+
+	// Call the registered Before Function
+	if s.beforeFunc != nil {
+		(*s.beforeFunc)(&RequestInfo{
+			Request: r,
+			Method:  method,
+		})
+	}
+
 	// Call the service method.
 	reply := reflect.New(methodSpec.replyType)
 
@@ -187,25 +204,33 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		errResult = errInter.(error)
 	}
 
-	// Call the registered After Function
-	if s.afterFunc != nil {
-		(*s.afterFunc)(&RequestInfo{
-			Method: method,
-			Error:  errResult,
-		})
-	}
-
 	// Prevents Internet Explorer from MIME-sniffing a response away
 	// from the declared content-type
 	w.Header().Set("x-content-type-options", "nosniff")
 	// Encode the response.
 	if errWrite := codecReq.WriteResponse(w, reply.Interface(), errResult); errWrite != nil {
-		writeError(w, 400, errWrite.Error())
+		s.writeError(w, 400, errWrite.Error())
+	} else {
+		// Call the registered After Function
+		if s.afterFunc != nil {
+			(*s.afterFunc)(&RequestInfo{
+				Request:    r,
+				Method:     method,
+				Error:      errResult,
+				StatusCode: 200,
+			})
+		}
 	}
 }
 
-func writeError(w http.ResponseWriter, status int, msg string) {
+func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
 	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	fmt.Fprint(w, msg)
+	if s.afterFunc != nil {
+		(*s.afterFunc)(&RequestInfo{
+			Error:      fmt.Errorf(msg),
+			StatusCode: status,
+		})
+	}
 }

--- a/server.go
+++ b/server.go
@@ -122,15 +122,21 @@ func (s *Server) HasMethod(method string) bool {
 }
 
 // RegisterBeforeFunc registers the specified function as the function
-// that will be called before every request
-func (s *Server) RegisterBeforeFunc(f func(i *RequestInfo)) error {
+// that will be called before every request.
+//
+// Note: Only one function can be registered, subsequent calls to this
+// method will overwrite all the previous functions.
+func (s *Server) RegisterBeforeFunc(f func(i *RequestInfo)) {
 	s.beforeFunc = f
 	return nil
 }
 
 // RegisterAfterFunc registers the specified function as the function
 // that will be called after every request
-func (s *Server) RegisterAfterFunc(f func(i *RequestInfo)) error {
+//
+// Note: Only one function can be registered, subsequent calls to this
+// method will overwrite all the previous functions.
+func (s *Server) RegisterAfterFunc(f func(i *RequestInfo)) {
 	s.afterFunc = f
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -128,7 +128,6 @@ func (s *Server) HasMethod(method string) bool {
 // method will overwrite all the previous functions.
 func (s *Server) RegisterBeforeFunc(f func(i *RequestInfo)) {
 	s.beforeFunc = f
-	return nil
 }
 
 // RegisterAfterFunc registers the specified function as the function
@@ -138,7 +137,6 @@ func (s *Server) RegisterBeforeFunc(f func(i *RequestInfo)) {
 // method will overwrite all the previous functions.
 func (s *Server) RegisterAfterFunc(f func(i *RequestInfo)) {
 	s.afterFunc = f
-	return nil
 }
 
 // ServeHTTP

--- a/server_test.go
+++ b/server_test.go
@@ -80,18 +80,3 @@ func TestRegisterTCPService(t *testing.T) {
 		t.Errorf("Expected error on service2")
 	}
 }
-
-func TestRegisterBeforeAfterFunc(t *testing.T) {
-	var err error
-	s := NewServer()
-
-	err = s.RegisterBeforeFunc(func(i *RequestInfo) {})
-	if err != nil {
-		t.Errorf("Expected to be nil")
-	}
-
-	err = s.RegisterAfterFunc(func(i *RequestInfo) {})
-	if err != nil {
-		t.Errorf("Expected to be nil")
-	}
-}

--- a/server_test.go
+++ b/server_test.go
@@ -80,3 +80,18 @@ func TestRegisterTCPService(t *testing.T) {
 		t.Errorf("Expected error on service2")
 	}
 }
+
+func TestRegisterBeforeAfterFunc(t *testing.T) {
+	var err error
+	s := NewServer()
+
+	err = s.RegisterBeforeFunc(func(i *RequestInfo) {})
+	if err != nil {
+		t.Errorf("Expected to be nil")
+	}
+
+	err = s.RegisterAfterFunc(func(i *RequestInfo) {})
+	if err != nil {
+		t.Errorf("Expected to be nil")
+	}
+}


### PR DESCRIPTION
We use these function with the information provided to set up things (usually before the request), to track timing, request, errors, etc.