### PR TITLE
Initialize empty slice on reply

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -43,6 +43,10 @@ func (t *Service1) ResponseError(r *http.Request, req *Service1Request, res *Ser
 	return ErrResponseError
 }
 
+func (s *Service1) GetAllEmpty(r *http.Request, req *Service1Request, res *[]Service1Response) error {
+	return nil
+}
+
 func execute(t *testing.T, s *rpc.Server, method string, req, res interface{}) error {
 	if !s.HasMethod(method) {
 		t.Fatal("Expected to be registered:", method)
@@ -91,5 +95,16 @@ func TestService(t *testing.T) {
 
 	if code := executeRaw(t, s, &Service1BadRequest{"Service1.Multiply"}, &res); code != 400 {
 		t.Errorf("Expected http response code 400, but got %v", code)
+	}
+}
+
+func TestServiceSlice(t *testing.T) {
+	s := rpc.NewServer()
+	s.RegisterCodec(NewCodec(), "application/json")
+	s.RegisterService(new(Service1), "")
+
+	res := []Service1Response{}
+	if err := execute(t, s, "Service1.GetAllEmpty", &Service1Request{}, &res); err != nil {
+		t.Error("Expected err to be nil, but got:", err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -149,6 +149,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Call the service method.
 	reply := reflect.New(methodSpec.replyType)
 
+	// Initialize empty slice
+	if methodSpec.replyType.Kind() == reflect.Slice {
+		reply.Elem().Set(reflect.MakeSlice(methodSpec.replyType, 0, 0))
+	}
+
 	// omit the HTTP request if the service method doesn't accept it
 	var errValue []reflect.Value
 	if serviceSpec.passReq {


### PR DESCRIPTION
Because slices are not initialized in the server, when the reply is not used by the called method, it will return a `nil` result causing the `DecodeClientResponse` to return the `result is null` error.

Because we usually initialize structs we should retain the same behavior and have slices initialized to empty.
