### PR TITLE
encode json with indent

### DIFF
--- a/v2/json2/json_test.go
+++ b/v2/json2/json_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gorilla/rpc/v2"
+	"github.com/QianChenglong/rpc/v2"
 )
 
 // ResponseRecorder is an implementation of http.ResponseWriter that

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -7,11 +7,12 @@ package json2
 
 import (
 	// "encoding/json"
+
 	"net/http"
 
-	"github.com/klauspost/json"
+	"github.com/klauspost/json" // for encode with indent
 
-	"github.com/gorilla/rpc/v2"
+	"github.com/QianChenglong/rpc/v2"
 )
 
 var null = json.RawMessage([]byte("null"))

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -6,8 +6,10 @@
 package json2
 
 import (
-	"encoding/json"
+	// "encoding/json"
 	"net/http"
+
+	"github.com/klauspost/json"
 
 	"github.com/gorilla/rpc/v2"
 )
@@ -171,7 +173,8 @@ func (c *CodecRequest) writeServerResponse(w http.ResponseWriter, res *serverRes
 	if c.request.Id != nil {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		encoder := json.NewEncoder(c.encoder.Encode(w))
-		err := encoder.Encode(res)
+		// err := encoder.Encode(res)
+		err := encoder.EncodeIndent(res, "", "  ")
 
 		// Not sure in which case will this happen. But seems harmless.
 		if err != nil {


### PR DESCRIPTION
Change standard library of json to github.com/klauspost/json in order to encode json with indent.
So it will be human readable when debug.
