### PR TITLE
[bug] Header write order (Content-Type vs. status) fixed.

### DIFF
--- a/v2/protorpc/server.go
+++ b/v2/protorpc/server.go
@@ -136,12 +136,11 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) 
 
 func (c *CodecRequest) writeServerResponse(w http.ResponseWriter, status int, res *serverResponse) {
 	b, err := json.Marshal(res.Result)
-	if err == nil {
-		w.WriteHeader(status)
-		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.Write(b)
-	} else {
-		// Not sure in which case will this happen. But seems harmless.
+	if err != nil {
 		rpc.WriteError(w, 400, err.Error())
 	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	w.Write(b)
 }


### PR DESCRIPTION
- writeServerResponse was writing the status before the Content-Type. This was
  not failing tests as Go would correctly sniff the MIME type and set it
  accordingly, but the order has been corrected regardless.
- have also added a test case to prevent any future regressions.

Addresses https://github.com/gorilla/rpc/issues/38