### PR TITLE
v2/json2: Support request params as object and array.

### DIFF
--- a/v2/json2/json_test.go
+++ b/v2/json2/json_test.go
@@ -77,6 +77,15 @@ type Service1NoParamsRequest struct {
 	ID uint64 `json:"id"`
 }
 
+type Service1ParamsArrayRequest struct {
+	V string `json:"jsonrpc"`
+	P []struct {
+		T string
+	} `json:"params"`
+	M  string `json:"method"`
+	ID uint64 `json:"id"`
+}
+
 type Service1Response struct {
 	Result int
 }
@@ -149,6 +158,25 @@ func TestService(t *testing.T) {
 	// No parameters.
 	res = Service1Response{}
 	if err := executeRaw(t, s, &Service1NoParamsRequest{"2.0", "Service1.Multiply", 1}, &res); err != nil {
+		t.Error(err)
+	}
+	if res.Result != Service1DefaultResponse {
+		t.Errorf("Wrong response: got %v, want %v", res.Result, Service1DefaultResponse)
+	}
+
+	// Parameters as by-position.
+	res = Service1Response{}
+	req := Service1ParamsArrayRequest{
+		V: "2.0",
+		P: []struct {
+			T string
+		}{{
+			T: "test",
+		}},
+		M:  "Service1.Multiply",
+		ID: 1,
+	}
+	if err := executeRaw(t, s, &req, &res); err != nil {
 		t.Error(err)
 	}
 	if res.Result != Service1DefaultResponse {

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -123,17 +123,35 @@ func (c *CodecRequest) Method() (string, error) {
 	return "", c.err
 }
 
-// ReadRe<quest fills the request object for the RPC method.
+// ReadRequest fills the request object for the RPC method.
+//
+// ReadRequest parses request parameters in two supported forms in
+// accordance with http://www.jsonrpc.org/specification#parameter_structures
+//
+// by-position: params MUST be an Array, containing the
+// values in the Server expected order.
+//
+// by-name: params MUST be an Object, with member names
+// that match the Server expected parameter names. The
+// absence of expected names MAY result in an error being
+// generated. The names MUST match exactly, including
+// case, to the method's expected parameters.
 func (c *CodecRequest) ReadRequest(args interface{}) error {
 	if c.err == nil && c.request.Params != nil {
 		// Note: if c.request.Params is nil it's not an error, it's an optional member.
 		// JSON params structured object. Unmarshal to the args object.
-		err := json.Unmarshal(*c.request.Params, args)
-		if err != nil {
-			c.err = &Error{
-				Code:    E_INVALID_REQ,
-				Message: err.Error(),
-				Data:    c.request.Params,
+		if err := json.Unmarshal(*c.request.Params, args); err != nil {
+			// Clearly JSON params is not a structured object,
+			// fallback and attempt an unmarshal with JSON params as
+			// array value and RPC params is struct. Unmarshal into
+			// array containing the request struct.
+			params := [1]interface{}{args}
+			if err = json.Unmarshal(*c.request.Params, &params); err != nil {
+				c.err = &Error{
+					Code:    E_INVALID_REQ,
+					Message: err.Error(),
+					Data:    c.request.Params,
+				}
 			}
 		}
 	}


### PR DESCRIPTION
RPC 2.0 Specification allows for both request params
as object and as an array. Handle both cases.

Excerpts from JSON RPC 2.0 spec:
```
If present, parameters for the rpc call MUST be provided
as a Structured value. Either by-position through an Array
or by-name through an Object.

by-position:
params MUST be an Array, containing the values in the
Server expected order.

by-name:
params MUST be an Object, with member names that match the
Server expected parameter names. The absence of expected
names MAY result in an error being generated. The names
MUST match exactly, including case, to the method's
expected parameters.
```