### PR TITLE
Allow default value for request content type

### DIFF
--- a/server.go
+++ b/server.go
@@ -150,8 +150,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if idx != -1 {
 		contentType = contentType[:idx]
 	}
-	codec := s.codecs[strings.ToLower(contentType)]
-	if codec == nil {
+	var codec Codec
+	if contentType == "" && len(s.codecs) == 1 {
+		// If Content-Type is not set and only one codec has been registered,
+		// then default to that codec.
+		for _, c := range s.codecs {
+			codec = c
+		}
+	} else if codec = s.codecs[strings.ToLower(contentType)]; codec == nil {
 		s.writeError(w, 415, "rpc: unrecognized Content-Type: "+contentType)
 		return
 	}

--- a/v2/server.go
+++ b/v2/server.go
@@ -102,8 +102,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if idx != -1 {
 		contentType = contentType[:idx]
 	}
-	codec := s.codecs[strings.ToLower(contentType)]
-	if codec == nil {
+	var codec Codec
+	if contentType == "" && len(s.codecs) == 1 {
+		// If Content-Type is not set and only one codec has been registered,
+		// then default to that codec.
+		for _, c := range s.codecs {
+			codec = c
+		}
+	} else if codec = s.codecs[strings.ToLower(contentType)]; codec == nil {
 		WriteError(w, 415, "rpc: unrecognized Content-Type: "+contentType)
 		return
 	}

--- a/v2/server_test.go
+++ b/v2/server_test.go
@@ -7,6 +7,7 @@ package rpc
 
 import (
 	"net/http"
+	"strconv"
 	"testing"
 )
 
@@ -50,5 +51,113 @@ func TestRegisterService(t *testing.T) {
 	err = s.RegisterService(service2, "")
 	if err == nil {
 		t.Errorf("Expected error on service2")
+	}
+}
+
+// MockCodec decodes to Service1.Multiply.
+type MockCodec struct {
+	A, B int
+}
+
+func (c MockCodec) NewRequest(*http.Request) CodecRequest {
+	return MockCodecRequest{c.A, c.B}
+}
+
+type MockCodecRequest struct {
+	A, B int
+}
+
+func (r MockCodecRequest) Method() (string, error) {
+	return "Service1.Multiply", nil
+}
+
+func (r MockCodecRequest) ReadRequest(args interface{}) error {
+	req := args.(*Service1Request)
+	req.A, req.B = r.A, r.B
+	return nil
+}
+
+func (r MockCodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}) {
+	res := reply.(*Service1Response)
+	w.Write([]byte(strconv.Itoa(res.Result)))
+}
+
+func (r MockCodecRequest) WriteError(w http.ResponseWriter, status int, err error) {
+	w.WriteHeader(status)
+	w.Write([]byte(err.Error()))
+}
+
+type MockResponseWriter struct {
+	header http.Header
+	Status int
+	Body   string
+}
+
+func NewMockResponseWriter() *MockResponseWriter {
+	header := make(http.Header)
+	return &MockResponseWriter{header: header}
+}
+
+func (w *MockResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *MockResponseWriter) Write(p []byte) (int, error) {
+	w.Body = string(p)
+	if w.Status == 0 {
+		w.Status = 200
+	}
+	return len(p), nil
+}
+
+func (w *MockResponseWriter) WriteHeader(status int) {
+	w.Status = status
+}
+
+func TestServeHTTP(t *testing.T) {
+	const (
+		A = 2
+		B = 3
+	)
+	expected := A * B
+
+	s := NewServer()
+	s.RegisterService(new(Service1), "")
+	s.RegisterCodec(MockCodec{A, B}, "mock")
+
+	r, err := http.NewRequest("POST", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set("Content-Type", "mock; dummy")
+	w := NewMockResponseWriter()
+	s.ServeHTTP(w, r)
+	if w.Status != 200 {
+		t.Errorf("Status was %d, should be 200.", w.Status)
+	}
+	if w.Body != strconv.Itoa(expected) {
+		t.Errorf("Response body was %s, should be %s.", w.Body, strconv.Itoa(expected))
+	}
+
+	// Test wrong Content-Type
+	r.Header.Set("Content-Type", "invalid")
+	w = NewMockResponseWriter()
+	s.ServeHTTP(w, r)
+	if w.Status != 415 {
+		t.Errorf("Status was %d, should be 415.", w.Status)
+	}
+	if w.Body != "rpc: unrecognized Content-Type: invalid" {
+		t.Errorf("Wrong response body.")
+	}
+
+	// Test omitted Content-Type; codec should default to the sole registered one.
+	r.Header.Del("Content-Type")
+	w = NewMockResponseWriter()
+	s.ServeHTTP(w, r)
+	if w.Status != 200 {
+		t.Errorf("Status was %d, should be 200.", w.Status)
+	}
+	if w.Body != strconv.Itoa(expected) {
+		t.Errorf("Response body was %s, should be %s.", w.Body, strconv.Itoa(expected))
 	}
 }


### PR DESCRIPTION
If Content-Type is not set in the request and only one codec has been
registered, then default to that codec.