### PR TITLE
Second Unmarshal Args Error

### DIFF
--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -146,7 +146,7 @@ func (c *CodecRequest) ReadRequest(args interface{}) error {
 			// array value and RPC params is struct. Unmarshal into
 			// array containing the request struct.
 			params := [1]interface{}{args}
-			if err = json.Unmarshal(*c.request.Params, &params); err != nil {
+			if json.Unmarshal(*c.request.Params, &params) != nil{
 				c.err = &Error{
 					Code:    E_INVALID_REQ,
 					Message: err.Error(),


### PR DESCRIPTION
This error message useless because It will be the same in all situations and you will lose second error and it overlapping custom UnmarshalJSON method error.
