### PR TITLE
added intercept function

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ package rpc
 import (
 	"context"
 	"net/http"
+	"runtime"
 	"strconv"
 	"testing"
 )
@@ -192,6 +193,11 @@ func TestServeHTTP(t *testing.T) {
 }
 
 func TestInterception(t *testing.T) {
+	if runtime.Version() < "go1.7" {
+		// this test case uses the context package which is not available in go < 1.7
+		return
+	}
+
 	const (
 		A = 2
 		B = 3


### PR DESCRIPTION
Allows to register a function that runs before the service method and returns a `*http.Request`. I use it to prepare the request context based on the RequestInfo.

```
        var RPCServer = rpc.NewServer()
	RPCServer.RegisterInterceptFunc(func(i *rpc.RequestInfo) *http.Request {
		ctx := i.Request.Context()
		ctx = trace.NewContext(ctx, trace.New("rpc", i.Method))
		return i.Request.WithContext(ctx)
	})
	RPCServer.RegisterAfterFunc(func(i *rpc.RequestInfo) {
		ctx := i.Request.Context()
		if tr, ok := trace.FromContext(ctx); ok {
			if i.Error != nil {
				tr.LazyPrintf(i.Error.Error(), true)
			}
			tr.Finish()
		}
	})
```