### PR TITLE
Fix: set response 'Content-Type' header before calling 'WriteHeader'

### DIFF
--- a/protorpc/server.go
+++ b/protorpc/server.go
@@ -127,6 +127,7 @@ func (c *CodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}, m
 		Error:  &null,
 		Id:     c.request.Id,
 	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if methodErr != nil {
 		// Propagate error message as string.
 		res.Error = methodErr.Error()
@@ -136,7 +137,6 @@ func (c *CodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}, m
 		}{res.Error}
 		w.WriteHeader(500)
 	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	encoder := json.NewEncoder(w)
 	encoder.Encode(res.Result)
 	return nil

--- a/server.go
+++ b/server.go
@@ -257,8 +257,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
 	fmt.Fprint(w, msg)
 	if s.afterFunc != nil {
 		s.afterFunc(&RequestInfo{

--- a/v2/json/server.go
+++ b/v2/json/server.go
@@ -145,8 +145,8 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, _ int, err error) {
 func (c *CodecRequest) writeServerResponse(w http.ResponseWriter, status int, res *serverResponse) {
 	b, err := json.Marshal(res)
 	if err == nil {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(status)
 		w.Write(b)
 	} else {
 		// Not sure in which case will this happen. But seems harmless.

--- a/v2/server.go
+++ b/v2/server.go
@@ -158,7 +158,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func WriteError(w http.ResponseWriter, status int, msg string) {
-	w.WriteHeader(status)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
 	fmt.Fprint(w, msg)
 }


### PR DESCRIPTION
w.Header().Set(...) won't work after WriteHeader called