### PR TITLE
Return E_PARSE error when JSON can't be parsed

### DIFF
--- a/v2/json2/json_test.go
+++ b/v2/json2/json_test.go
@@ -10,10 +10,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/rpc/v2"
-	"strings"
 )
 
 // ResponseRecorder is an implementation of http.ResponseWriter that

--- a/v2/json2/json_test.go
+++ b/v2/json2/json_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/rpc/v2"
+	"strings"
 )
 
 // ResponseRecorder is an implementation of http.ResponseWriter that
@@ -136,6 +137,16 @@ func executeRaw(t *testing.T, s *rpc.Server, req interface{}, res interface{}) e
 	return DecodeClientResponse(w.Body, res)
 }
 
+func executeInvalidJSON(t *testing.T, s *rpc.Server, res interface{}) error {
+	r, _ := http.NewRequest("POST", "http://localhost:8080/", strings.NewReader(`not even a json`))
+	r.Header.Set("Content-Type", "application/json")
+
+	w := NewRecorder()
+	s.ServeHTTP(w, r)
+
+	return DecodeClientResponse(w.Body, res)
+}
+
 func TestService(t *testing.T) {
 	s := rpc.NewServer()
 	s.RegisterCodec(NewCodec(), "application/json")
@@ -181,6 +192,15 @@ func TestService(t *testing.T) {
 	}
 	if res.Result != Service1DefaultResponse {
 		t.Errorf("Wrong response: got %v, want %v", res.Result, Service1DefaultResponse)
+	}
+
+	res = Service1Response{}
+	if err := executeInvalidJSON(t, s, &res); err == nil {
+		t.Error("Expected to receive an E_PARSE error, but got nil")
+	} else if jsonRpcErr, ok := err.(*Error); !ok {
+		t.Errorf("Expected to receive an Error, but got %T: %s", err, err)
+	} else if jsonRpcErr.Code != E_PARSE {
+		t.Errorf("Expected to receive an E_PARSE JSON-RPC error (%d) but got %d", E_PARSE, jsonRpcErr.Code)
 	}
 }
 


### PR DESCRIPTION
An empty-body HTTP 200 OK response was returned to malformed requests
because:
 - As JSON could not be parsed, res.Version was empty and `err` was
 being overwritten by E_INVALID_REQ. Solution: only check that if there
 was no parse error.
 - As JSON could not be parsed, red.Id was empty and writeServerResponse
 was considering it was a Notification request, so the response was
 discarded. Solution: if ID is empty, make sure we're not trying to
 write an E_PARSE error.