### PR TITLE
Return HTTP 500 if can't encode the response

### DIFF
--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -193,7 +193,7 @@ func (c *CodecRequest) writeServerResponse(w http.ResponseWriter, res *serverRes
 
 		// Not sure in which case will this happen. But seems harmless.
 		if err != nil {
-			rpc.WriteError(w, 400, err.Error())
+			rpc.WriteError(w, http.StatusInternalServerError, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
If we can't encode the response, it's our fault, not client's, so it's a
500, not a 400.