### PR TITLE
Added optional error mapper to json2.Codec

### DIFF
--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -59,7 +59,7 @@ type serverResponse struct {
 // Codec
 // ----------------------------------------------------------------------------
 
-// NewcustomCodec returns a new JSON Codec based on passed encoder selector.
+// NewCustomCodec returns a new JSON Codec based on passed encoder selector.
 func NewCustomCodec(encSel rpc.EncoderSelector) *Codec {
 	return &Codec{encSel: encSel}
 }

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -184,9 +184,7 @@ func (c *CodecRequest) WriteResponse(w http.ResponseWriter, reply interface{}) {
 }
 
 func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) {
-	if c.errorMapper != nil {
-		err = c.errorMapper(err)
-	}
+	err = c.tryToMapIfNotAnErrorAlready(err)
 	jsonErr, ok := err.(*Error)
 	if !ok {
 		jsonErr = &Error{
@@ -200,6 +198,13 @@ func (c *CodecRequest) WriteError(w http.ResponseWriter, status int, err error) 
 		Id:      c.request.Id,
 	}
 	c.writeServerResponse(w, res)
+}
+
+func (c CodecRequest) tryToMapIfNotAnErrorAlready(err error) error {
+	if _, ok := err.(*Error); ok || c.errorMapper == nil {
+		return err
+	}
+	return c.errorMapper(err)
 }
 
 func (c *CodecRequest) writeServerResponse(w http.ResponseWriter, res *serverResponse) {

--- a/v2/json2/server.go
+++ b/v2/json2/server.go
@@ -64,6 +64,12 @@ func NewCustomCodec(encSel rpc.EncoderSelector) *Codec {
 	return &Codec{encSel: encSel}
 }
 
+// NewCustomCodecWithErrorMapper returns a new JSON Codec based on the passed encoder selector
+// and also accepts an errorMapper function.
+// The errorMapper function will be called if the Service implementation returns an error, with that
+// error as a param, replacing it by the value returned by this function. This function is intended
+// to decouple your service implementation from the codec itself, making possible to return abstract
+// errors in your service, and then mapping them here to the JSON-RPC error codes.
 func NewCustomCodecWithErrorMapper(encSel rpc.EncoderSelector, errorMapper func(error) error) *Codec {
 	return &Codec{
 		encSel:      encSel,


### PR DESCRIPTION
Application error mapping can't be done in the Service implementation,
and it can't be a Server dependency, because error mapping depends on
the codec being used: if we're using JSONRPC we'll want to map our
errors to *json2.Error.

This introduces a new constructor for the codec, just to maintain the
backwards-compatibility, NewCustomCodecWithErrorMapper, which accepts a
simple function `func(error) error`. That one is passed to each
CodecRequest, and if an error has to be returned and this function is
not nil, we'll invoke it assigning the result to the error.