### PR TITLE
Initialize module: go mod init github.com/gorilla/rpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/gorilla/rpc


### PR DESCRIPTION
Fixes #78 

**Summary of Changes**

Initialize module to fix go list error when using IDEs like GoLand. The specific error is:

go list -m: github.com/gorilla/rpc@v1.2.0+incompatible: invalid version: +incompatible suffix not allowed: major version v1 is compatible
