### PR TITLE
changing the documentation hyperlink to doc.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 
 gorilla/rpc is a foundation for RPC over HTTP services, providing access to the exported methods of an object through HTTP requests.
 
-Read the full documentation here: https://www.gorillatoolkit.org/pkg/rpc
+Read the full documentation here: https://pkg.go.dev/github.com/gorilla/rpc#section-documentation


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
After a quick gothrough, it seems redirecting to the actually Documentation available on pkg.go.dev (https://github.com/gorilla/rpc/blob/main/doc.go) could help in eliminating the infinite loop.

If this suits as considerable idea, I'll update it for rest of the modules too (ref: https://github.com/gorilla/rpc/issues/85#issuecomment-756984668).

## Related Tickets & Documents

- Related Issue #85 

## Added/updated tests?

- [ ] Yes
- [x] No, just a doc update
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
